### PR TITLE
Transport emissions for LPG improved

### DIFF
--- a/snakefile.smk
+++ b/snakefile.smk
@@ -5,9 +5,9 @@ SCENARIOS = ['Social_benefits', 'Private_benefits', 'Social_private_benefits']
 # SCENARIOS, = glob_wildcards("../Clean cooking Africa paper/04. OnSSTOVE inputs/LPG International price - Rural-Urban/Scenario_files/{scenario}/BDI_scenario_file.csv")
 
 
-# COUNTRIES = ['GMB']
+COUNTRIES = ['ZAF']
 
-COUNTRIES = ['Africa']
+# COUNTRIES = ['Africa']
 
 # COUNTRIES = ['AGO', 'BDI', 'BEN', 'BFA', 'BWA', 'CAF', 'CIV', 'CMR',
              # 'COD', 'COG', 'DJI', 'ERI', 'ETH', 'GAB', 'GHA', 'GIN',
@@ -16,16 +16,16 @@ COUNTRIES = ['Africa']
              # 'SEN', 'SLE', 'SOM', 'SSD', 'SWZ', 'TCD', 'TGO', 'TZA',
              # 'UGA', 'ZAF', 'ZMB', 'ZWE']
 
-# rule all:
-    # input:
-        # expand("../Clean cooking Africa paper/06. Results/LPG International price - Rural-Urban/{country}/{scenario}/results.pkl",
-               # country=COUNTRIES,
-               # scenario=SCENARIOS)
-
 rule all:
     input:
-         expand("../Clean cooking Africa paper/06. Results/LPG International price - Rural-Urban/Africa/{scenario}/results.pkl",
+        expand("../Clean cooking Africa paper/06. Results/LPG International price - Rural-Urban/{country}/{scenario}/results.pkl",
+               country=COUNTRIES,
                scenario=SCENARIOS)
+
+# rule all:
+#     input:
+#          expand("../Clean cooking Africa paper/06. Results/LPG International price - Rural-Urban/Africa/{scenario}/results.pkl",
+#                scenario=SCENARIOS)
 
 rule extract_forest:
     input:


### PR DESCRIPTION
This PR improves the calculations of carbon emissions for LPG transport, accounting for CO2, CO, N2O, BC and OC emissions. This closes #239 