### PR TITLE
Rewritten get_raster_distance method using scipy instead of GDAL

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,23 +5,16 @@
 # Required
 version: 2
 
-# Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: "ubuntu-20.04"
   tools:
-    python: "3.9"
-    # You can also specify other tool versions:
-    # nodejs: "16"
-    # rust: "1.55"
-    # golang: "1.17"
+    python: "mambaforge-4.10"
+
+
+conda:
+  file: envs/readthedocs_env.yaml
+
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
    configuration: docs/conf.py
-
-# If using Sphinx, optionally build your docs in additional formats such as PDF
-# formats:
-#    - pdf
-
-conda:
-  file: readthedocs_env.yaml

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 contextily
 dill
-gdal
 geopandas
 matplotlib
 numpydoc
@@ -10,7 +9,8 @@ psycopg2
 psutil
 pydata-sphinx-theme
 python-decouple
-rasterio
+https://download.lfd.uci.edu/pythonlibs/archived/GDAL-3.4.3-cp310-cp310-win_amd64.whl
+https://download.lfd.uci.edu/pythonlibs/archived/rasterio-1.2.10-cp310-cp310-win_amd64.whl
 rasterstats
 scikit-learn
 scikit-image

--- a/envs/readthedocs_env.yaml
+++ b/envs/readthedocs_env.yaml
@@ -1,0 +1,21 @@
+name: readthedocs
+channels:
+  - bioconda
+  - jmcmurray
+  - conda-forge
+  - defaults
+dependencies:
+  - contextily
+  - dill
+  - geopandas
+  - matplotlib
+  - numpydoc
+  - plotnine
+  - psycopg2
+  - psutil
+  - pydata-sphinx-theme
+  - python-decouple
+  - rasterio
+  - rasterstats
+  - scikit-learn
+  - scikit-image

--- a/envs/snake_env.yaml
+++ b/envs/snake_env.yaml
@@ -1,3 +1,4 @@
+name: onstovesnake
 channels:
   - bioconda
   - jmcmurray
@@ -9,13 +10,12 @@ dependencies:
   - gdal
   - geopandas
   - matplotlib
-  - numpydoc
   - plotnine
   - psycopg2
   - psutil
-  - pydata-sphinx-theme
   - python-decouple
   - rasterio
   - rasterstats
   - scikit-learn
   - scikit-image
+  - snakemake-minimal

--- a/onstove/raster.py
+++ b/onstove/raster.py
@@ -1,8 +1,6 @@
-import os
 import glob
 import numpy as np
-from math import sqrt
-from heapq import heapify, heappush, heappop
+
 import rasterio
 import rasterio.mask
 from rasterio.merge import merge
@@ -12,8 +10,6 @@ from rasterio import features
 from rasterio.enums import Resampling as enumsResampling
 import geopandas as gpd
 import fiona
-import shapely
-from osgeo import gdal, osr
 import gzip
 
 
@@ -70,31 +66,6 @@ def polygonize(raster, mask=None):
     geoms = list(results)
     polygon = gpd.GeoDataFrame.from_features(geoms)
     return polygon
-
-
-def proximity_raster(src_filename, dst_filename, values, compression):
-    src_ds = gdal.Open(src_filename)
-    srcband = src_ds.GetRasterBand(1)
-    dst_filename = dst_filename
-
-    drv = gdal.GetDriverByName('GTiff')
-    dst_ds = drv.Create(dst_filename,
-                        src_ds.RasterXSize, src_ds.RasterYSize, 1,
-                        gdal.GetDataTypeByName('Float32'),
-                        options=['COMPRESS={}'.format(compression)])
-
-    dst_ds.SetGeoTransform(src_ds.GetGeoTransform())
-    dst_ds.SetProjection(src_ds.GetProjectionRef())
-
-    dstband = dst_ds.GetRasterBand(1)
-
-    gdal.ComputeProximity(srcband, dstband,
-                          ["VALUES={}".format(','.join([str(i) for i in values])),
-                           "DISTUNITS=GEO"])
-    srcband = None
-    dstband = None
-    src_ds = None
-    dst_ds = None
 
 
 def mask_raster(raster_path, mask_layer, output_file, nodata=0, compression='NONE',

--- a/scripts/sensitivity.py
+++ b/scripts/sensitivity.py
@@ -28,7 +28,7 @@ def run_model(country, model_file, sensitivity_file, tech_file, output_directory
 	# 3. Calculating benefits and costs of each technology and getting the max benefit technology for each cell
 	model.run(technologies=['Electricity', 'LPG', 'Biogas',
 							'Collected_Improved_Biomass', 'Collected_Traditional_Biomass', 'Charcoal ICS',
-							'Traditional_Charcoal'
+							'Traditional_Charcoal', 'Biomass Forced Draft', 'Pellets Forced Draft'
 							])
 
 	# 4. Save the summary


### PR DESCRIPTION
This PR rewrites the `get_raster_distance` from the `layer.VectorLayer` class with the ``proximity`` option, to remove the GDAL dependency completely. 