### PR TITLE
Added markers for test order

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,10 @@ name: OnStove tests
 on:
   push:
     branches: ['main']
-    paths: ['onstove/*', 'tests/*']
+    paths: ['onstove/*', 'onstove/tests/*']
   pull_request:
     branches: ['main']
-    paths: ['onstove/*', 'tests/*']
+    paths: ['onstove/*', 'onstove/tests/*']
 
 jobs:
   miniconda:

--- a/environment-tests.yml
+++ b/environment-tests.yml
@@ -15,7 +15,7 @@ dependencies:
   - python=>3.10
   - python-decouple
   - pytest
-  # - pytest-order
+  - pytest-order
   - rasterio
   - scikit-image
   - svgpathtools

--- a/onstove/model.py
+++ b/onstove/model.py
@@ -448,8 +448,12 @@ class DataProcessor:
         Saves all layers that have not been previously saved
         """
         datasets = self._get_layers(datasets)
-        datasets[self.mask_layer.category] = {self.mask_layer.name: self.mask_layer}
-        datasets[self.base_layer.category] = {self.base_layer.name: self.base_layer}
+        if self.mask_layer.category not in datasets.keys():
+            datasets[self.mask_layer.category] = {}
+        datasets[self.mask_layer.category][self.mask_layer.name] = self.mask_layer
+        if self.base_layer.category not in datasets.keys():
+            datasets[self.base_layer.category] = {}
+        datasets[self.base_layer.category][self.base_layer.name] = self.base_layer
         for category, layers in datasets.items():
             for name, layer in layers.items():
                 output_path = os.path.join(self.output_directory,

--- a/onstove/tests/test_model_prep.py
+++ b/onstove/tests/test_model_prep.py
@@ -1,7 +1,9 @@
 import os
+import pytest
 
 from onstove import VectorLayer, RasterLayer, OnStove
 
+@pytest.mark.order(after="test_data_processing.py::test_process_data")
 def test_prepare_model():
     # 1. Create an OnStove model
     output_directory = os.path.join('onstove', 'tests', 'output')

--- a/onstove/tests/test_model_run.py
+++ b/onstove/tests/test_model_run.py
@@ -1,7 +1,9 @@
 import os
+import pytest
 
 from onstove import OnStove
 
+@pytest.mark.order(after="test_model_prep.py::test_prepare_model")
 def test_run_model():
     # 1. Read the OnSSTOVE model
     country = 'Rwanda'

--- a/onstove/tests/test_plot_results.py
+++ b/onstove/tests/test_plot_results.py
@@ -56,6 +56,7 @@ def test_plot_maps():
                      rasterized=True, type='pdf')
     assert True
     
+@pytest.mark.order(after="test_model_run.py::test_run_model")    
 def test_plot_stats():
     # 1. Reading results
     country = 'Rwanda'

--- a/onstove/tests/test_plot_results.py
+++ b/onstove/tests/test_plot_results.py
@@ -1,7 +1,9 @@
 import os
+import pytest
 
 from onstove import OnStove
 
+@pytest.mark.order(after="test_model_run.py::test_run_model")
 def test_plot_maps():
     # 1. Reading results
     country = 'Rwanda'


### PR DESCRIPTION
This PR tries to solve the tests failing in the GitHub workflow. Markers where added to enforce test order using the `pytest-order` plugin. 

This closes #324.