### PR TITLE
Misalignment fixed

### DIFF
--- a/onstove/layer.py
+++ b/onstove/layer.py
@@ -273,15 +273,15 @@ class VectorLayer(_Layer):
                 self.data = self.data.query(query)
         self.path = path
 
-    def mask(self, mask_layer: gpd.GeoDataFrame, output_path: str = None, keep_geom_type=False):
+    def mask(self, mask_layer: 'VectorLayer', output_path: str = None, keep_geom_type=False):
         """Wrapper for the :doc:`geopandas:docs/reference/api/geopandas.GeoDataFrame.clip` method.
 
         Clip points, lines, or polygon geometries to the mask extent.
 
         Parameters
         ----------
-        mask_layer: GeoDataFrame
-            A :doc:`geopandas:docs/reference/api/geopandas.GeoDataFrame` object.
+        mask_layer: VectorLayer
+            A :class:`VectorLayer` object.
         output_path: str, optional
             A folder path where to save the output dataset. If not defined then the clipped dataset is not saved.
         """
@@ -964,6 +964,10 @@ class RasterLayer(_Layer):
              Include a pixel in the mask if it touches any of the shapes. If False, include a pixel only if its center
              is within one of the shapes, or if it is selected by Bresenham’s line algorithm.
         """
+        if mask_layer.data.crs != self.meta['crs']:
+            mask_layer = mask_layer.copy()
+            mask_layer.reproject(self.meta['crs'])
+
         rasterized_mask = mask_layer.rasterize(value=1, transform=self.meta['transform'],
                                                width=self.meta['width'], height=self.meta['height'],
                                                nodata=0, all_touched=all_touched)

--- a/onstove/model.py
+++ b/onstove/model.py
@@ -49,7 +49,7 @@ from plotnine import (
 from onstove.layer import VectorLayer, RasterLayer
 from onstove.technology import Technology, LPG, Biomass, Electricity, Biogas, Charcoal, MiniGrids
 from onstove.raster import sample_raster
-from onstove._utils import Processes
+from onstove._utils import Processes, raster_setter
 
 
 def timeit(func):
@@ -284,6 +284,9 @@ class DataProcessor:
                                     output_path=output_path,
                                     cell_width=self.cell_size[0],
                                     cell_height=self.cell_size[1])
+
+                if isinstance(self.mask_layer, VectorLayer):
+                    layer.mask(self.mask_layer)
 
                 self.base_layer = layer
 
@@ -1485,7 +1488,8 @@ class OnStove(DataProcessor):
         GHS_path: str
             Path to the GHS dataset
         """
-        self.raster_to_dataframe(GHS_path, name="IsUrban", method='sample')
+        ghs = raster_setter(GHS_path)
+        self.raster_to_dataframe(ghs, name="IsUrban", method='read', fill_nodata_method='interpolate')
 
         self.calibrate_current_pop()
 


### PR DESCRIPTION
This PR fixes #352, it implements:
* Masks the `base_layer` when initially reading it in the `DataProcessor` to ensure all datasets have the same dimensions at the end.
* Changes the `raster_to_dataframe` method from `sample` to `read` as the GHS layer should already been aligned with the `base_layer`
* When calling the `mask` method for the `RasterLayer` class, it first reprojects the `mask_layer` to the same crs of the `RasterLayer`.
* The order of the alignment and the masking in the notebook should change, to be aligning first and then masking, and the masking is only needed for the vector layers (i.e. mv lines). This I will do in #339.