### PR TITLE
AWE function and affordability categories

### DIFF
--- a/onstove/model.py
+++ b/onstove/model.py
@@ -56,6 +56,8 @@ from onstove.technology import Technology, LPG, Biomass, Electricity, Biogas, Ch
 from onstove.raster import sample_raster
 from onstove._utils import Processes, deep_update
 from onstove._layer_utils import raster_setter
+import scipy.stats as stats
+from scipy.interpolate import PchipInterpolator
 
 
 def timeit(func):
@@ -1249,7 +1251,9 @@ class OnStove(DataProcessor):
             'fnrb': 'fnrb',
             'vsl': 'vsl',
             'costofcarbonemissions': 'cost_of_carbon_emissions',
-            'minimumwage': 'minimum_wage'}
+            'minimumwage': 'minimum_wage',
+            'gdppc': 'gdp_pc',
+            'gini': 'gini'}
 
         self.specs = {self._replace_dict.get(k, k): v for k, v in self.specs.copy().items()}
 
@@ -2369,7 +2373,7 @@ class OnStove(DataProcessor):
                 self.gdf.loc[is_tech, "emission_costs_avoided"] = self.techs[tech].decreased_carbon_costs[index]
 
     def extract_wealth_index(self, wealth_index: str, file_type: str = "csv", x_column: str =  "longitude",
-                             y_column: str = "latitude", wealth_column: str = "rwi"):
+                             y_column: str = "latitude", wealth_column: str = "rwi", pareto_weight: float = 0.32):
 
         """Extracts the relative wealth index to a column called relative wealth in the :attr:`gdf`.
 
@@ -2386,7 +2390,7 @@ class OnStove(DataProcessor):
             The name of the column containing x-coordinates, only relevant when `file_type = csv`
         y_column: str, default "latitude"
             The name of the column containing y-coordinates, only relevant when `file_type = csv`
-        wealth_column: str, default "latitude"
+        wealth_column: str, default "rwi"
             The name of the column containing the wealth index, only relevant when file type is either `csv`, `point`
             or `polygon`
 
@@ -2444,6 +2448,101 @@ class OnStove(DataProcessor):
                                      fill_nodata_method='interpolate')
         else:
             raise ValueError("file_type needs to be either csv, raster, polygon or point.")
+
+        
+        
+        
+    def income_estimation(self, income_data: str, pareto_weight: float = 0.32):
+        """Estimates income of each cell in the study area.
+
+        The function approaches income estimation in two possible ways. When income data is provided, it uses it to simply extrapolate income values
+        in all cells, by corresponding the income values to the relative wealth index ranked (sorted) values. The income data should be a csv file with two columns:
+        percentile and income. The other alternative is to use the relative wealth index to estimate the absolute wealth estimate.
+        The absolute wealth is calculated using the relative wealth index, the Gini coefficient and the GDP per capita of the study area.
+        The relative wealth index, as indicated by [1], can be used to calculate an absolute wealth estimate. Given its use of GDP per capita and Gini coefficient,
+        it can be considered a rough estimation for income. This rough estimation is based on the work by [2], where a function describing wealth distribution in a
+        country was determined as the combination of a Pareto and a lognormal distribution. The two distributions are combined using a weight factor, 
+        which is set to 0.32 by default. The weight factor can be adjusted to fit the specific distribution of wealth in the study area. The authors of [2] 
+        argue that the weight factor of 0.32 captured best the wealth distribution in the study area of their analysis, especially in the case of poorer
+        households. The absolute wealth is then calculated using the inverse cumulative distribution function (ICDF) of the combined distribution function.
+        Relative wealth index values are sorted (or rather ranked) and the ICDF aproximmation corresponds each cell rank. This is later scaled
+        with the GDP per capita and the number of cells in the study area.
+        
+        Formula: absolute_wealth = ICDF(relative_wealth) * GDP per capita * number of cells / sum(ICDF(relative_wealth))
+
+        References
+        ----------
+        [1] G. Chi, H. Fang, S. Chatterjee, & J.E. Blumenstock, Microestimates of wealth for all low- and middle-income countries, 
+        Proc. Natl. Acad. Sci. U.S.A. 119 (3) e2113658119, https://doi.org/10.1073/pnas.2113658119 (2022).
+        [2] Hruschka DJ, Gerkey D, Hadley C. Estimating the absolute wealth of households. Bull World Health Organ. 
+        2015 Jul 1;93(7):483-90. doi: 10.2471/BLT.14.147082. Epub 2015 May 15. PMID: 26170506; PMCID: PMC4490812.
+
+        Parameters
+        ----------
+        income_data: str
+            The path to the income data used. The income data should be a csv file with two columns: percentile and income.
+        pareto_weight: float, default 0.32
+            Weight factor for the Pareto distribution to combine it with the lognormal distribution.
+
+        """
+
+        # Calculating the AWE
+
+        # First estimating the distributions
+
+        gdp_pc = self.specs['gdp_pc']
+        gini = self.specs['gini']
+
+        alpha_pareto = ((1+gini)/(2*gini))
+        xm_pareto = (1-(1/alpha_pareto))*gdp_pc
+
+        x_values = np.linspace(0, 5 * gdp_pc, 1000)  # Mock values to create the distributions
+                                                    # High income values captured by 5 times GPDpc, ASUMPTION
+
+        dist_pareto = stats.pareto(b=alpha_pareto, scale=xm_pareto)
+        cdf_pareto = dist_pareto.cdf(x_values)
+    
+        # Lognormal distribution
+    
+        sigma_lognorm = np.sqrt(2)*stats.norm.ppf((gini+1)/2)
+        mu_lognorm = np.log(gdp_pc)-((sigma_lognorm**2)/2)
+    
+        dist_lognorm = stats.lognorm(s=sigma_lognorm, scale=np.exp(mu_lognorm))
+        cdf_lognorm = dist_lognorm.cdf(x_values)
+
+        # Combined Distribution
+
+        w_pareto = pareto_weight
+        w_lognorm = 1 - w_pareto
+
+        cdf_combined = w_pareto * cdf_pareto + w_lognorm * cdf_lognorm
+
+        # Interpolation ICDF
+
+        icdf = PchipInterpolator(cdf_combined, x_values)
+        n = len(self.gdf)
+        probs = np.linspace(1/n, 1, n)          
+        icdf = icdf(probs)
+
+        #Calculating AWE
+
+        self.gdf = self.gdf.sort_values(by=['relative_wealth'], ascending=True)
+        
+        self.gdf["icdf"] = icdf
+        sum_icdf = np.sum(self.gdf['icdf'])
+        self.gdf['absolute_wealth'] = self.gdf['icdf']*gdp_pc*n/sum_icdf
+
+        if income_data and income_data.strip():
+            income_data = pd.read_csv(income_data)
+            income = np.array(income_data['income'])
+            percentiles = np.array(income_data['percentile'])/100
+            income = PchipInterpolator(percentiles, income)
+            income = income(probs)
+            self.gdf['income'] = income
+
+
+        self.gdf = self.gdf.sort_index()
+
 
     @staticmethod
     def _re_name(df, labels, variable):

--- a/onstove/technology.py
+++ b/onstove/technology.py
@@ -735,7 +735,10 @@ class Technology:
 
             model.gdf['affordability_category_{}'.format(self.name)] = pd.cut(model.gdf['cost_income_ratio_{}'.format(self.name)], bins=bins, labels=categories, right=False)
             model.gdf['affordability_category_{}'.format(self.name)] = model.gdf['affordability_category_{}'.format(self.name)].cat.add_categories(['Not available'])
-            model.gdf['affordability_category_{}'.format(self.name)].fillna('Not available', inplace=True)
+            model.gdf.loc[model.gdf['cost_income_ratio_{}'.format(self.name)] > 1, 'affordability_category_{}'.format(self.name)] = categories[-1]
+            model.gdf.loc[model.gdf['cost_income_ratio_{}'.format(self.name)] < 0, 'affordability_category_{}'.format(self.name)] = categories[0]
+
+
         except KeyError:
             raise KeyError(f"The affordability categories could not be assigned for {self.name}.")
 
@@ -1842,7 +1845,7 @@ class Electricity(Technology):
         self.households = model.gdf['Households'] * factor
 
     def affordability_categories(self, model: 'onstove.OnStove', income_data: bool = False, categories: list = ['<5%', '5-15%', '15%+']):
-        """This method expands :meth:`Technology.affordability_categories` by constraining the availability of biogas.
+        """This method expands :meth:`Technology.affordability_categories` by constraining the availability of electricity.
         Parameters
         ----------
         model: OnStove model


### PR DESCRIPTION
Addressing issue #404 (onstove.OnStove.income_estimation()) and starting to address issue #414 (onstove.technology.affordability_categories()). Regarding this second issue, open points are:
- How to handle negative costs?
- How to call it within onstove.OnStove.run()?
- Momentarily tested by calling in the Jupyter notebook after model.run():

> `for tech in country.techs:
>     try:
>         country.techs[tech].affordability_categories(country, income_data = True)
>     except KeyError:
>         continue`

Implementation works, yet it shows the following warning in each tech: FutureWarning: A value is trying to be set on a copy of a DataFrame or Series through chained assignment using an inplace method.
The behavior will change in pandas 3.0. This inplace method will never work because the intermediate object on which we are setting values always behaves as a copy.

For example, when doing 'df[col].method(value, inplace=True)', try using 'df.method({col: value}, inplace=True)' or df[col] = df[col].method(value) instead, to perform the operation inplace on the original object.

- Finally, how to implement this last method for the maximimum benefit technology?